### PR TITLE
Add standalone parts list and board photo link

### DIFF
--- a/Device/parts_list.md
+++ b/Device/parts_list.md
@@ -1,0 +1,37 @@
+# Raspberry Pi Audio Logger Parts List
+
+This list covers all hardware needed to assemble the logger.
+
+## Electronics
+
+- **Raspberry Pi Zero 2 W**  
+  https://www.amazon.com/Pi-Zero-WH-Quad-Core-Bluetooth/dp/B0DKKXS4RV/ref=sr_1_2?dib=eyJ2IjoiMSJ9.3BENuF2Ktu1UHOlVshSOQYPwU1089JijS12avrC0DqA1_i-XNbdxfYBez71IsuTi7DIazUzS27rvSGpEuHLvjf7BpvSBsSDZU4HkBMTONSdibqXZQCP0JZW8R_b-c64OernNrWmtTOd0lwOIhmR9hYoAjrT6xw5-8ijoVgocDqv-oexaC8GwC6Hdiw6YY8lRQKR-kyq-SecOtyZ9zBLrcTMlZL2a0FKn
+- **INMP441 Microphone (I2S)**  
+  https://www.amazon.com/dp/B09G4RNT3G?ref_=ppx_hzsearch_conn_dt_b_fed_asin_title_3
+- **RGB LED (Common Cathode)**  
+  https://www.amazon.com/Tricolor-Multicolor-Lighting-Electronics-Components/dp/B01C19ENDM/ref=sr_1_1_sspa?crid=20CM0W3PCB4Y2&dib=eyJ2IjoiMSJ9.F6UlFFmxsevWAA03DWtuhbMg1RLY2S0r7AtU4cNUMbQHfmepxLUfHpJXBx40e9nvwYaJrgA8_H77w2Xvd4PjAB-pznvGGB3Jze2kVTpL3_s_oarxqFMVLY19jghClktTTzSPulGJPZrbAtwcDqKrxQz5jdxWWr3QE20m8q9GSb8vtWf8Dl-8bw3VOmP2xjRTtn4GiQVqnXArgMhLjqL6EJ2HS1UbkP8sngrkhRYuqJQ.47xh_KeLKLr55R8y48kuF9Ok_7LnvY-NyYBO8u0Ndbw&dib_tag=se&keywords=led%2Bcommon%2Bcathode&qid=1751921708&sprefix=led%2Bcommon%2Bcathod%2Caps%2C173&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1
+- **2x Push Buttons**  
+  https://www.amazon.com/TWTADE-Yellow-Orange-6x6x5mm-Tactile/dp/B07C7211PJ/ref=sr_1_1?crid=9ELB6S3VQQFD&dib=eyJ2IjoiMSJ9.qUPJzNGvbRCxaQVxxlN1cNrsldT8cQkTxpHhyI939xsTne6aWz1XASVqHEHOnfm1cWPCL_6EJ32H5W8NVFwh-XenZ7SttZfqI3fAf0zz0yCY-Y4aujLDQBm6KC_ftIAwiSPsB7YyGhqk7IOU_600my7qIshsUbm_QJJ63KZIg9m6HjGdL-xcYaGS8Zky0gihRnmPeHUY-WK4Otqvk0uCzJjdGdV0LBuem_Ma68iC9M8.2mJqONhLjP8XCjmRpfJ6-rTSfZaMw8p8l2f0VdrQYaI&dib_tag=se&keywords=push+buttons+small+breadboard&qid=1751921757&sprefix=push+buttons+small+breadborad%2Caps%2C156&sr=8-1
+- **3x 330Ω Resistors** (RGB LED)
+- **2x 10kΩ Resistors** (buttons)
+  https://www.amazon.com/TMH-525-Metal-Film-Resistor/dp/B0FD3LP495/ref=sr_1_5?crid=2IQ3H3Z3P8LJL&dib=eyJ2IjoiMSJ9.BNJiYWYIJ8SO47xLLe9PpqcaOZjcKGRLwvIjgBKv_sKVHiTVpdkLKe7aA8emVTH5abKzqAB96HSzh8dB37h_mDAVreytniQtijPVtaNEZjcU5oPLWKaFX7xyUcZKaOONZFXzWLD4EqzLDzw51ik9VoVNHo-D-r8wh-RMn3gcA0LcI6WpnBI91imjBMegf28yPfShG32j_KeRYKIflR1uX0cuFG-ZGm2F-rn0bYUj7TM.aHpC3fvroy2iCLOdhjwi8gZbttNqojdGxbnxwsOHyqQ&dib_tag=se&keywords=resistor+kit&qid=1751921810&sprefix=resistor%2Caps%2C173&sr=8-5
+- **Perma-Proto Board**  
+  https://www.amazon.com/dp/B0B2RQDJ54?ref=ppx_yo2ov_dt_b_fed_asin_title
+- **M2.5 Standoffs**  
+  https://www.amazon.com/dp/B0756CW6Y2?ref=ppx_yo2ov_dt_b_fed_asin_title
+- **5V Buck Converter**  
+  https://www.amazon.com/dp/B07L76KLRY?ref=ppx_yo2ov_dt_b_fed_asin_title
+- **1100mAh Battery**  
+  https://www.amazon.com/Hiteuoms-Rechargeable-Development-Protection-Insulated/dp/B0F3875HJY/ref=sr_1_5_sspa?crid=3V12UWWJCTP8O&dib=eyJ2IjoiMSJ9.PBkWNEKk_tyzi56PMU9A4LQ-DrgJa-scxaIUnYNwm270drndqW4rCJakcW_xwAICFD7boSK4tDZERt8jVy9g8kz62P1bJuCWlBPZWFNQJN7hZrgRgLXLqM4P7c_JYATGejY32_W-GkQU5EhMHg_YjniHmdz9XI3srHjhsA9JlXj0tpOFKZdHqMiIoet4Y90xX75VaEy4bGCE_n9ngxl7ir1jS6s6w08BSqJEvUVTJvlwtJ2aR1BZJVVCZCL60iPCy7nuxoDl8LHojlfbPIVOqH2iXabtXZgWh6OHxG2G5ls.UOYh6kZTnTFmZwg_SXhjJnTaLY4Omy3xG5R6zbcDyrY&dib_tag=se&keywords=1100+mah+battery&qid=1751921580&sprefix=1100+ma%2Caps%2C178&sr=8-5-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1
+- **USB-C Lithium Battery Charger**  
+  https://www.amazon.com/Lithium-Battery-Charging-Protection-Functions/dp/B07MDPLQ18/ref=sr_1_13?crid=10JIA67S03THO&dib=eyJ2IjoiMSJ9.9cVxWnjGGc0nyWP6OrsKQ1Qog6IOHmh5tZfJmZmaCtqQZebRx3I6gDas7EQjrysqdn3mMRyXgvhpRMZxu_R8UQSJ1lB_ajF93uiS7DqW2_0BQitp-_bKa89EmCRlxKiTvHVo_1-MGe0R51g0iL21VKOHUtNNHwbnlvf5LYnGeuITb8etsa5HnBfIKHXimRJl640ee8zqcZ2_e98n2YcTm3jo6ySJjWBbvEUBlxWuwes.0Onj4crz5aaITOzlB8RnosRM99lHVEH7AAagIEvdScs&dib_tag=se&keywords=usbc%2B3.7%2Bvolt&qid=1751921609&sprefix=usbc%2B3.7%2Bvolt%2Caps%2C189&sr=8-13&th=1
+
+## 3D Printed Parts
+
+The `Device/Cad` directory contains STL models for printing:
+
+- **Scribe - Back Shell.stl**
+- **Scribe - TopFrame.stl**
+- **2x Scribe - Button Extender.stl** (one for each button)
+- **Lanyard or strap** for carrying the recorder
+

--- a/Device/wiring_instructions.md
+++ b/Device/wiring_instructions.md
@@ -1,24 +1,8 @@
 # Raspberry Pi Audio Logger Wiring Instructions
 
-## Components
+This guide explains how to connect the electronics on the breadboard. A full list of parts is available in [parts_list.md](parts_list.md).
 
-- **Raspberry Pi Zero 2 W**
-https://www.amazon.com/Pi-Zero-WH-Quad-Core-Bluetooth/dp/B0DKKXS4RV/ref=sr_1_2?dib=eyJ2IjoiMSJ9.3BENuF2Ktu1UHOlVshSOQYPwU1089JijS12avrC0DqA1_i-XNbdxfYBez71IsuTi7DIazUzS27rvSGpEuHLvjf7BpvSBsSDZU4HkBMTONSdibqXZQCP0JZW8R_b-c64OernNrWmtTOd0lwOIhmR9hYoAjrT6xw5-8ijoVgocDqv-oexaC8GwC6Hdiw6YY8lRQKR-kyq-SecOtyZ9zBLrcTMlZL2a0FKnyfva27WMB40.UTozmk2Z782ommJ-fKMI1sRr2vzrIQIyFkYnhxq_fD0&dib_tag=se&keywords=raspberry+pi+zero+w+2&qid=1751921685&sr=8-2
-- **INMP441 Microphone (I2S)**
-https://www.amazon.com/dp/B09G4RNT3G?ref_=ppx_hzsearch_conn_dt_b_fed_asin_title_3
-- **RGB LED (Common Cathode)**
-https://www.amazon.com/Tricolor-Multicolor-Lighting-Electronics-Components/dp/B01C19ENDM/ref=sr_1_1_sspa?crid=20CM0W3PCB4Y2&dib=eyJ2IjoiMSJ9.F6UlFFmxsevWAA03DWtuhbMg1RLY2S0r7AtU4cNUMbQHfmepxLUfHpJXBx40e9nvwYaJrgA8_H77w2Xvd4PjAB-pznvGGB3Jze2kVTpL3_s_oarxqFMVLY19jghClktTTzSPulGJPZrbAtwcDqKrxQz5jdxWWr3QE20m8q9GSb8vtWf8Dl-8bw3VOmP2xjRTtn4GiQVqnXArgMhLjqL6EJ2HS1UbkP8sngrkhRYuqJQ.47xh_KeLKLr55R8y48kuF9Ok_7LnvY-NyYBO8u0Ndbw&dib_tag=se&keywords=led%2Bcommon%2Bcathode&qid=1751921708&sprefix=led%2Bcommon%2Bcathod%2Caps%2C173&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1
-- **2x Push Buttons**
-https://www.amazon.com/TWTADE-Yellow-Orange-6x6x5mm-Tactile/dp/B07C7211PJ/ref=sr_1_1?crid=9ELB6S3VQQFD&dib=eyJ2IjoiMSJ9.qUPJzNGvbRCxaQVxxlN1cNrsldT8cQkTxpHhyI939xsTne6aWz1XASVqHEHOnfm1cWPCL_6EJ32H5W8NVFwh-XenZ7SttZfqI3fAf0zz0yCY-Y4aujLDQBm6KC_ftIAwiSPsB7YyGhqk7IOU_600my7qIshsUbm_QJJ63KZIg9m6HjGdL-xcYaGS8Zky0gihRnmPeHUY-WK4Otqvk0uCzJjdGdV0LBuem_Ma68iC9M8.2mJqONhLjP8XCjmRpfJ6-rTSfZaMw8p8l2f0VdrQYaI&dib_tag=se&keywords=push+buttons+small+breadboard&qid=1751921757&sprefix=push+buttons+small+breadborad%2Caps%2C156&sr=8-1
-- **3x 330Ω Resistors (for RGB LED)**
-2x 10kΩ Resistors (for Buttons)
-
-https://www.amazon.com/TMH-525-Metal-Film-Resistor/dp/B0FD3LP495/ref=sr_1_5?crid=2IQ3H3Z3P8LJL&dib=eyJ2IjoiMSJ9.BNJiYWYIJ8SO47xLLe9PpqcaOZjcKGRLwvIjgBKv_sKVHiTVpdkLKe7aA8emVTH5abKzqAB96HSzh8dB37h_mDAVreytniQtijPVtaNEZjcU5oPLWKaFX7xyUcZKaOONZFXzWLD4EqzLDzw51ik9VoVNHo-D-r8wh-RMn3gcA0LcI6WpnBI91imjBMegf28yPfShG32j_KeRYKIflR1uX0cuFG-ZGm2F-rn0bYUj7TM.aHpC3fvroy2iCLOdhjwi8gZbttNqojdGxbnxwsOHyqQ&dib_tag=se&keywords=resistor+kit&qid=1751921810&sprefix=resistor%2Caps%2C173&sr=8-5
-
-add a link to these standoffs https://www.amazon.com/dp/B0756CW6Y2?ref=ppx_yo2ov_dt_b_fed_asin_title this board https://www.amazon.com/dp/B0B2RQDJ54?ref=ppx_yo2ov_dt_b_fed_asin_title this buck converter https://www.amazon.com/dp/B07L76KLRY?ref=ppx_yo2ov_dt_b_fed_asin_title this battery https://www.amazon.com/Hiteuoms-Rechargeable-Development-Protection-Insulated/dp/B0F3875HJY/ref=sr_1_5_sspa?crid=3V12UWWJCTP8O&dib=eyJ2IjoiMSJ9.PBkWNEKk_tyzi56PMU9A4LQ-DrgJa-scxaIUnYNwm270drndqW4rCJakcW_xwAICFD7boSK4tDZERt8jVy9g8kz62P1bJuCWlBPZWFNQJN7hZrgRgLXLqM4P7c_JYATGejY32_W-GkQU5EhMHg_YjniHmdz9XI3srHjhsA9JlXj0tpOFKZdHqMiIoet4Y90xX75VaEy4bGCE_n9ngxl7ir1jS6s6w08BSqJEvUVTJvlwtJ2aR1BZJVVCZCL60iPCy7nuxoDl8LHojlfbPIVOqH2iXabtXZgWh6OHxG2G5ls.UOYh6kZTnTFmZwg_SXhjJnTaLY4Omy3xG5R6zbcDyrY&dib_tag=se&keywords=1100+mah+battery&qid=1751921580&sprefix=1100+ma%2Caps%2C178&sr=8-5-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1
-
-this battery charger https://www.amazon.com/Lithium-Battery-Charging-Protection-Functions/dp/B07MDPLQ18/ref=sr_1_13?crid=10JIA67S03THO&dib=eyJ2IjoiMSJ9.9cVxWnjGGc0nyWP6OrsKQ1Qog6IOHmh5tZfJmZmaCtqQZebRx3I6gDas7EQjrysqdn3mMRyXgvhpRMZxu_R8UQSJ1lB_ajF93uiS7DqW2_0BQitp-_bKa89EmCRlxKiTvHVo_1-MGe0R51g0iL21VKOHUtNNHwbnlvf5LYnGeuITb8etsa5HnBfIKHXimRJl640ee8zqcZ2_e98n2YcTm3jo6ySJjWBbvEUBlxWuwes.0Onj4crz5aaITOzlB8RnosRM99lHVEH7AAagIEvdScs&dib_tag=se&keywords=usbc%2B3.7%2Bvolt&qid=1751921609&sprefix=usbc%2B3.7%2Bvolt%2Caps%2C189&sr=8-13&th=1
----
+![Breadboard layout](board.jpeg)
 
 ## Wiring Diagram
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The hardware build uses the following components:
 - Two push buttons: one for highlights and one for initiating uploads
 - RGB LED with resistors for visual feedback
 
-Wiring diagrams and a detailed parts list are provided in
+Wiring diagrams are provided in
 [Device/wiring_instructions.md](Device/wiring_instructions.md).
+See [Device/parts_list.md](Device/parts_list.md) for a complete list of
+required components.
 
 ## 3D-Printed Case
 


### PR DESCRIPTION
## Summary
- split wiring guide and parts list
- list 3D printed parts including two button extenders and mention lanyard
- link parts list from README and add board image to wiring instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c380444b08331ac72786d7cfa88da